### PR TITLE
Add ESCAPE_ALL option to glob pattern compiler

### DIFF
--- a/src/test/java/com/hrakaroo/glob/EscapeTest.java
+++ b/src/test/java/com/hrakaroo/glob/EscapeTest.java
@@ -35,4 +35,13 @@ public class EscapeTest {
         Assertions.assertThrows(RuntimeException.class, () -> GlobPattern.compile(pattern, '%', '_', GlobPattern.CASE_INSENSITIVE | GlobPattern.HANDLE_ESCAPES));
     }
 
+    @Test
+    public void testEscapeAll() {
+        String pattern = "\\\\\\%_\\_";
+        MatchingEngine matchingEngine = GlobPattern.compile(pattern, '%', '_', GlobPattern.ESCAPE_ALL);
+        assert (matchingEngine.matches("\\%x_"));
+        assert (!matchingEngine.matches("\\%xy"));
+        assert (!matchingEngine.matches("\\zx_"));
+    }
+
 }


### PR DESCRIPTION
This flag is added so the escaping mechanism is more flexible.
With the old HANDLE_ESCAPES flag, only a few escape sequences are accepted, and others generate errors. And so we have to first escape the pattern string and then feed it into the glob engine.
If we don't use the HANDLE_ESCAPES flag, then it does not know the difference between `?` and `\?` unless we use a reserved character to represent match-one and match-any.
So, this PR proposes another mode which is ESCAPE_ALL:
- Everything after a backslash represents an exact match on itself.
- Otherwise, the match-one and match-any characters work as normal.